### PR TITLE
added USB camera preview window. still needs right aspect ratio/ui fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,14 @@
                     </div>
 
                     <div class="flexContainerV" id="cameraControlExpandedBodyContainer">
+		      <div id="videocontainer">
+			<video autoplay="true" id="videopreview">
+	
+			</video>
+			  <select id="webcamSelect" onchange="SelectPreviewCamera()">
+                             <option value="-1">--Select a webcam--</option>
+                          </select>
+		      </div>
                         <div class="tableControl">
                             <h3>Connection</h3>
                             <table>

--- a/style.css
+++ b/style.css
@@ -468,3 +468,24 @@ table, td {
 td, tr {
     align-items: center;
 }
+
+/* video preview */
+
+#videocontainer {
+    width: 400px;
+    height: 250px;
+    background: white;
+    position: absolute;
+    left: 800px;	   
+}
+
+#videopreview {
+    
+}
+
+
+#webcamSelect {
+    top: -160px;
+    position: relative;
+    left: -300px;
+}


### PR DESCRIPTION
[may not be ready to be pushed to the "main" branch, but pushing it for testing]


This is the first (working?) attempt to include a preview window with a live webcam feed. Note that the browser will only access the camera if the file is loaded from a web server. Loading as a file will not work. The simplest way to set up a web server is Python. Just run 

python3 -m http.server --bind 127.0.0.1 9000

in the same directory as index.html 

This will start a web server on localhost port 9000.

Access the page using:

http://localhost:9000/

Select the webcam for the dropdown. This will require some form of HDMI->USB interface.

Issues remaining: mostly UI. For example, the video window size must be adjusted according to the camera requirements not to distort the aspect ratio.

